### PR TITLE
Added support for choosing region and/or endpoint for publishing data to Amazon Kinesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Note that the current implementation doesn't insert records in the same order as
 | log4j.appender.[APPENDER_NAME].threadCount | 20 | Number of parallel threads for publishing logs to configured Kinesis stream
 | log4j.appender.[APPENDER_NAME].bufferSize | 2000 | Maximum number of outstanding log messages to keep in memory
 | log4j.appender.[APPENDER_NAME].shutdownTimeout | 30 | Seconds to send buffered messages before application JVM quits normally
-
+| log4j.appender.[APPENDER_NAME].endpoint | kinesis.us-east-1.amazonaws.com | Amazon Kinesis endpoint to make requests to, if configured this overrides default endpoint for the configured region
+| log4j.appender.[APPENDER_NAME].region | us-east-1 | Amazon Kinesis endpoint in this configured region will be used for making requests unless overridden by log4j.appender.[APPENDER_NAME].endpoint
 
 ## Recommendations/Information
 

--- a/src/main/java/com/amazonaws/services/kinesis/log4j/AppenderConstants.java
+++ b/src/main/java/com/amazonaws/services/kinesis/log4j/AppenderConstants.java
@@ -14,11 +14,13 @@
  ******************************************************************************/
 package com.amazonaws.services.kinesis.log4j;
 
+import com.amazonaws.regions.Regions;
+
 /**
  * Contains constants and default configuration values for the appender
  */
 public class AppenderConstants {
-  public static final String USER_AGENT_STRING = "kinesis-log4j-appender/1.0.0";
+  public static final String USER_AGENT_STRING = "kinesis-log4j-appender/1.0.1";
   // Default values
   public static final String DEFAULT_ENCODING = "UTF-8";
   public static final int DEFAULT_MAX_RETRY_COUNT = 3;
@@ -27,4 +29,6 @@ public class AppenderConstants {
   public static final int DEFAULT_THREAD_COUNT = 20;
   public static final int DEFAULT_SHUTDOWN_TIMEOUT_SEC = 30;
   public static final int DEFAULT_THREAD_KEEP_ALIVE_SEC = 30;
+  public static final String DEFAULT_REGION = Regions.US_EAST_1.getName();
+  public static final String DEFAULT_SERVICE_NAME = "kinesis";
 }

--- a/src/main/resources/log4j-sample.properties
+++ b/src/main/resources/log4j-sample.properties
@@ -45,3 +45,10 @@ log4j.appender.KINESIS.bufferSize=1000
 log4j.appender.KINESIS.threadCount=20
 #optional, defaults to 30 seconds
 log4j.appender.KINESIS.shutdownTimeout=30
+#optional, defaults to kinesis.us-east-1.amazonaws.com or 
+#Amazon Kinesis endpoint in the configured ".region".
+#If configured, this endpoint is used instead of the default
+#Amazon Kinesis endpoint in the configured ".region"
+log4j.appender.KINESIS.endpoint=kinesis.us-east-1.amazonaws.com
+#optional, defaults to us-east-1
+log4j.appender.KINESIS.region=us-east-1

--- a/src/main/resources/log4j-sample.xml
+++ b/src/main/resources/log4j-sample.xml
@@ -40,6 +40,13 @@
     <param name="threadCount" value="20" />
     <!--optional, defaults to 30 seconds-->
     <param name="shutdownTimeout" value="30" />
+    <!-- optional, defaults to kinesis.us-east-1.amazonaws.com or -->
+    <!-- Amazon Kinesis endpoint in the configured ".region". -->
+    <!-- If configured, this endpoint is used instead of the default-->
+    <!-- Amazon Kinesis endpoint in the configured ".region"-->
+    <param name="endpoint" value="kinesis.us-east-1.amazonaws.com" />
+    <!--optional, defaults to us-east-1-->
+    <param name="region" value="us-east-1" />
   </appender>
 
   <logger name="KinesisLogger" additivity="false">


### PR DESCRIPTION
This adds features requested in #3 and #4 by adding both region and endpoint options. If endpoint is configured, requests are made to the destination configured in endpoint instead of default endpoint in the configured region.
